### PR TITLE
Add Vue component inside Markdown files and fix images

### DIFF
--- a/components/AppBlog.vue
+++ b/components/AppBlog.vue
@@ -6,7 +6,7 @@
           <source
             media="(max-width: 767px)"
             sizes="(max-width: 614px) 100vw, 614px"
-            :srcset="`${img}?style=placholder 614w`"
+            :srcset="`${img}?style=placeholder 614w`"
             :data-srcset="
               `
                 ${img}?style=cover-1x1-6 614w,
@@ -14,14 +14,14 @@
                 ${img}?style=cover-1x1-4 532w,
                 ${img}?style=cover-1x1-3 439w,
                 ${img}?style=cover-1x1-2 333w,
-                ${img}?style=cover-1x1-1 200w 
+                ${img}?style=cover-1x1-1 200w
               `
             "
           />
           <source
             media="(min-width: 768px) and (max-width: 991px)"
             sizes="(max-width: 1169px) 100vw, 818px"
-            :srcset="`${img}?style=placholder 818w`"
+            :srcset="`${img}?style=placeholder 818w`"
             :data-srcset="
               `
                 ${img}?style=cover-4x3-5 818w,
@@ -35,7 +35,7 @@
           <source
             media="(min-width: 992px) and (max-width: 1199px)"
             sizes="(max-width: 1818px) 100vw, 1091px"
-            :srcset="`${img}?style=placholder 1091w`"
+            :srcset="`${img}?style=placeholder 1091w`"
             :data-srcset="
               `
                 ${img}?style=cover-16x9-7 1091w,
@@ -54,8 +54,8 @@
             width="1920"
             height="640"
             :alt="title"
-            :src="`${img}?style=placholder`"
-            :srcset="`${img}?style=placholder 1920w`"
+            :src="`${img}?style=placeholder`"
+            :srcset="`${img}?style=placeholder 1920w`"
             :data-srcset="
               `
                 ${img}?style=cover-10 1920w,

--- a/components/AppImg.vue
+++ b/components/AppImg.vue
@@ -1,6 +1,6 @@
 <template>
   <img
-    :data-src="lazySrc"
+    :src="lazySrc"
     :data-srcset="lazySrcset"
     :style="style"
     :alt="alt"
@@ -9,7 +9,7 @@
 </template>
 
 <script>
-import lozad from "lozad";
+// import lozad from "lozad";
 
 export default {
   name: `AppImg`,
@@ -78,28 +78,28 @@ export default {
 
       return style;
     }
-  },
-  mounted() {
-    // As soon as the <img> element triggers
-    // the `load` event, the loading state is
-    // set to `false`, which removes the apsect
-    // ratio we've applied earlier.
-    const setLoadingState = () => {
-      this.loading = false;
-    };
-    this.$el.addEventListener(`load`, setLoadingState);
-    // We remove the event listener as soon as
-    // the component is destroyed to prevent
-    // potential memory leaks.
-    this.$once(`hook:destroyed`, () => {
-      this.$el.removeEventListener(`load`, setLoadingState);
-    });
-
-    // We initialize Lozad.js on the root
-    // element of our component.
-    const observer = lozad(this.$el);
-    observer.observe();
   }
+  // mounted() {
+  //   // As soon as the <img> element triggers
+  //   // the `load` event, the loading state is
+  //   // set to `false`, which removes the apsect
+  //   // ratio we've applied earlier.
+  //   const setLoadingState = () => {
+  //     this.loading = false;
+  //   };
+  //   this.$el.addEventListener(`load`, setLoadingState);
+  //   // We remove the event listener as soon as
+  //   // the component is destroyed to prevent
+  //   // potential memory leaks.
+  //   this.$once(`hook:destroyed`, () => {
+  //     this.$el.removeEventListener(`load`, setLoadingState);
+  //   });
+
+  //   // We initialize Lozad.js on the root
+  //   // element of our component.
+  //   const observer = lozad(this.$el);
+  //   observer.observe();
+  // }
 };
 </script>
 

--- a/components/DynamicMarkdown.vue
+++ b/components/DynamicMarkdown.vue
@@ -1,0 +1,23 @@
+<script>
+import AppImg from "./AppImg.vue";
+
+export default {
+  /*eslint-disable */
+  components: {
+    AppImg
+  },
+  props: ["renderFunc", "staticRenderFuncs"],
+
+  created() {
+    this.templateRender = new Function(this.renderFunc)();
+    this.$options.staticRenderFns = new Function(this.staticRenderFuncs)();
+  },
+
+  render(createElement) {
+    return this.templateRender
+      ? this.templateRender()
+      : createElement("div", "Rendering");
+  }
+  /* eslint-enable */
+};
+</script>

--- a/config/build.js
+++ b/config/build.js
@@ -51,10 +51,10 @@ export default {
     config.module.rules.push({
       test: /\.md$/,
       loader: "frontmatter-markdown-loader",
+      include: path.resolve(__dirname, "../contents/blogs"),
       options: {
-        vue: true,
-        markdown(body) {
-          return md.render(body);
+        vue: {
+          root: "dynamicMarkdown"
         }
       }
     });

--- a/config/build.js
+++ b/config/build.js
@@ -1,38 +1,38 @@
 import path from "path";
-import MarkdownIt from "markdown-it";
-// import hljs from "highlight.js";
-import mip from "markdown-it-prism";
-import mila from "markdown-it-link-attributes";
-import mia from "markdown-it-anchor";
-import mitdr from "markdown-it-toc-done-right";
-import slugify from "@sindresorhus/slugify";
+// import MarkdownIt from "markdown-it";
+// // import hljs from "highlight.js";
+// import mip from "markdown-it-prism";
+// import mila from "markdown-it-link-attributes";
+// import mia from "markdown-it-anchor";
+// import mitdr from "markdown-it-toc-done-right";
+// import slugify from "@sindresorhus/slugify";
 
-import miri from "../plugins/markdown-it-responsive-image";
+// import miri from "../plugins/markdown-it-responsive-image";
 import { isDev } from "./utils";
-import { miriConf } from "./config";
+// import { miriConf } from "./config";
 
-const md = new MarkdownIt({
-  html: true,
-  typographer: true
-});
-md.use(mip);
-md.use(miri, miriConf);
-md.use(mila, {
-  pattern: /(http|https|ftp|ftps):\/\/[a-zA-Z0-9\-.]+\.[a-zA-Z]{2,3}(\/\S*)?/,
-  attrs: {
-    target: "_blank",
-    rel: "noopener noreferrer"
-  }
-});
-md.use(mia, {
-  permalink: true,
-  permalinkBefore: true,
-  permalinkSymbol: "🔗",
-  slugify
-});
-md.use(mitdr, {
-  slugify
-});
+// const md = new MarkdownIt({
+//   html: true,
+//   typographer: true
+// });
+// md.use(mip);
+// md.use(miri, miriConf);
+// md.use(mila, {
+//   pattern: /(http|https|ftp|ftps):\/\/[a-zA-Z0-9\-.]+\.[a-zA-Z]{2,3}(\/\S*)?/,
+//   attrs: {
+//     target: "_blank",
+//     rel: "noopener noreferrer"
+//   }
+// });
+// md.use(mia, {
+//   permalink: true,
+//   permalinkBefore: true,
+//   permalinkSymbol: "🔗",
+//   slugify
+// });
+// md.use(mitdr, {
+//   slugify
+// });
 
 export default {
   parallel: isDev,

--- a/contents/blogs/fix-cors-issue-firebase-google-cloud/index.en.md
+++ b/contents/blogs/fix-cors-issue-firebase-google-cloud/index.en.md
@@ -54,7 +54,8 @@ jefrydco@cloudshell:~ (PROJECT-ID)$
 
 The bucket URL can be found from Firebase dashboard on Storage menu like this image:
 
-![Firebase Storage Image](/content/2019/04/firebase-storage-image-by-jefrydco.jpg)
+<AppImg lazySrc="/content/2019/04/firebase-storage-image-by-jefrydco.jpg"/>
 
 Or from Google Cloud Console dashboard on Storage menu like this image:
-![Google Cloud Storage](/content/2019/04/google-cloud-storage-image-by-jefrydco.jpg)
+
+<AppImg lazySrc="/content/2019/04/google-cloud-storage-image-by-jefrydco.jpg"/>

--- a/pages/blog/_slug/index.vue
+++ b/pages/blog/_slug/index.vue
@@ -14,7 +14,7 @@
                 ${blog.img}?style=cover-1x1-4 532w,
                 ${blog.img}?style=cover-1x1-3 439w,
                 ${blog.img}?style=cover-1x1-2 333w,
-                ${blog.img}?style=cover-1x1-1 200w 
+                ${blog.img}?style=cover-1x1-1 200w
               `
             "
           />
@@ -121,8 +121,10 @@
                   {{ locale.name }}
                 </nuxt-link>
               </div>
-              <!-- eslint-disable-next-line -->
-              <div v-html="blog.content"></div>
+              <DynamicMarkdown
+                :render-func="blog.renderFunc"
+                :static-render-funcs="blog.staticRenderFuncs"
+              />
               <footer>
                 <p>
                   {{ $t("coverImageFrom") }}
@@ -173,6 +175,7 @@
 
 <script>
 import AppProfile from "~/components/AppProfile";
+import DynamicMarkdown from "~/components/DynamicMarkdown";
 import AppToTop from "~/components/AppToTop";
 
 import lazyload from "~/mixins/lazyload";
@@ -182,7 +185,8 @@ import readingTime from "reading-time";
 export default {
   components: {
     AppProfile,
-    AppToTop
+    AppToTop,
+    DynamicMarkdown
   },
   mixins: [lazyload],
   head() {
@@ -346,6 +350,8 @@ export default {
         updatedDate: blog.attributes.updatedDate,
         slug: blog.attributes.slug,
         readingTime: readingTime(blog.html),
+        renderFunc: blog.vue.render,
+        staticRenderFuncs: blog.vue.staticRenderFns,
         fullPath,
         discussLink: `https://twitter.com/search?q=${encodeURIComponent(
           fullPath

--- a/pages/blog/_slug/index.vue
+++ b/pages/blog/_slug/index.vue
@@ -338,11 +338,10 @@ export default {
     return {
       availableLocales,
       blog: {
-        img: blog.attributes.img,
+        img: `/img/${blog.attributes.img}`,
         imgCreator: blog.attributes.imgCreator,
         title: blog.attributes.title,
         description: blog.attributes.description,
-        content: blog.html,
         postedDate: blog.attributes.postedDate,
         updatedDate: blog.attributes.updatedDate,
         slug: blog.attributes.slug,

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -8,7 +8,7 @@
         <app-blog
           v-for="(blog, i) in blogs"
           :key="`blog_${i}`"
-          :img="blog.img"
+          :img="`/img/${blog.img}`"
           :title="blog.title"
           :description="blog.description"
           :posted-date="blog.postedDate"
@@ -150,7 +150,7 @@ export default {
               url: `https://jefrydco.id/blog/${blog.slug}`,
               image: {
                 "@type": "imageObject",
-                url: `https://jefrydco.id${blog.img}`,
+                url: `https://jefrydco.id/img/${blog.img}`,
                 height: "1920",
                 width: "614"
               },


### PR DESCRIPTION
- [x]  **Fix images URL**: I fixed you some URLs that were not working.
- [x]  **Add dynamic markdown component to load `AppImg` Vue component on it.**
- [x]  **Comment unnecessary code.**

Comments:
- I added `AppImg` in the way I have in my website just to try any vue component inside the Markdown.

- Consider to delete `MarkdownIt` from your package.json and configuration since you are importing it already with `frontmatter-markdown-loader`.

- I commented your `lozad` import and methods because you haven't installed that package. Are you aware of that?